### PR TITLE
配置Uvicorn服务指向部署模块

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ onnxruntime
 fastapi
 uvicorn[standard]
 onnx
+requests


### PR DESCRIPTION
Update Streamlit frontend to consume predictions from a remote FastAPI ONNX service.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-e46ce902-b53f-408f-a0f9-9a4b41b48ab4) · [Cursor](https://cursor.com/background-agent?bcId=bc-e46ce902-b53f-408f-a0f9-9a4b41b48ab4)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)